### PR TITLE
Minor bug on page 135: derivation for reiteration

### DIFF
--- a/forallx-yyc-prooftfl.tex
+++ b/forallx-yyc-prooftfl.tex
@@ -968,7 +968,7 @@ Suppose you have some sentence on some line of your deduction:
 You now want to repeat yourself, on some line $k$. You could just invoke the rule R, introduced in \S\ref{s:Further}. But equally well, you can do this with the \emph{basic} rules of \S\ref{s:BasicTFL}:
 \begin{proof}
 	\have[m]{a}{\meta{A}}
-	\have[k]{aa}{\meta{A} \eand \meta{A}}\ai{a}
+	\have[k]{aa}{\meta{A} \eand \meta{A}}\ai{a, a}
 	\have{a2}{\meta{A}}\ae{aa}
 \end{proof}
 To be clear: this is not a proof. Rather, it is a proof  \emph{scheme}. After all, it uses a variable, `$\meta{A}$', rather than a sentence of TFL, but the point is simple: Whatever sentences of TFL we plugged in for `$\meta{A}$', and whatever lines we were working on, we could produce a bona fide proof. So you can think of this as a recipe for producing proofs. 


### PR DESCRIPTION
Hi Richard,

I found a minor bug in the textbook. It appears on page 135, during the proof scheme for deriving reiteration (line k) ("$\land$I m" should be "$\land$I m,m"). Because on page 101 and 104, the rule for conjunction introduction states that the line number should be repeated even it come from the same line. 
On page 136, Line k + 4 's annotation also justifies my change because it has $\lor$I k+3,k+3. 
You can automatically merge it!

Thanks,
Simon Mo